### PR TITLE
[BACKLOG-12101] Fixes core-test dependency

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -235,9 +235,16 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-platform-core-test</artifactId>
+      <artifactId>pentaho-platform-core</artifactId>
       <version>${project.version}</version>
+      <classifier>tests</classifier>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
@pedrofvteixeira This should hopefully be the last change scheduler change for the platform mavenization.
Note: This might fail until the core creates a pentaho-platform-core-tests jar artifact.