### PR TITLE
[BACKLOG-12101] mavenizing platform repository module

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1027,7 +1027,8 @@
 		<dependency>
 			<groupId>pentaho</groupId>
 			<artifactId>pentaho-platform-core</artifactId>
-			<version>${project.version}-tests</version>
+			<version>${project.version}</version>
+			<classifier>tests</classifier>
 			<optional>true</optional>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
  - Fixed the way dependency is defined for platform-core-test