### PR TITLE
[BACKLOG-12101] Extracts TestQuartzScheduler from JaxWsSchedulerServiceIT for use in other modules

### DIFF
--- a/scheduler/src/it/java/org/pentaho/platform/scheduler2/blockout/PentahoBlockoutManagerIT.java
+++ b/scheduler/src/it/java/org/pentaho/platform/scheduler2/blockout/PentahoBlockoutManagerIT.java
@@ -43,7 +43,7 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.scheduler2.blockout.BlockoutManagerUtil.TIME;
 import org.pentaho.platform.scheduler2.quartz.test.StubUserDetailsService;
 import org.pentaho.platform.scheduler2.quartz.test.StubUserRoleListService;
-import org.pentaho.platform.scheduler2.ws.test.JaxWsSchedulerServiceIT.TestQuartzScheduler;
+import org.pentaho.platform.scheduler2.ws.test.TestQuartzScheduler;
 import org.pentaho.platform.scheduler2.ws.test.JaxWsSchedulerServiceIT.TstPluginManager;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/scheduler/src/it/java/org/pentaho/platform/scheduler2/quartz/test/QuartzSchedulerIT.java
+++ b/scheduler/src/it/java/org/pentaho/platform/scheduler2/quartz/test/QuartzSchedulerIT.java
@@ -45,7 +45,7 @@ import org.pentaho.platform.scheduler2.quartz.QuartzSchedulerAvailability;
 import org.pentaho.platform.scheduler2.recur.IncrementalRecurrence;
 import org.pentaho.platform.scheduler2.recur.RecurrenceList;
 import org.pentaho.platform.scheduler2.recur.SequentialRecurrence;
-import org.pentaho.platform.scheduler2.ws.test.JaxWsSchedulerServiceIT.TestQuartzScheduler;
+import org.pentaho.platform.scheduler2.ws.test.TestQuartzScheduler;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.springframework.security.core.userdetails.UserDetailsService;
 

--- a/scheduler/src/it/java/org/pentaho/platform/scheduler2/ws/test/JaxWsSchedulerServiceIT.java
+++ b/scheduler/src/it/java/org/pentaho/platform/scheduler2/ws/test/JaxWsSchedulerServiceIT.java
@@ -54,6 +54,7 @@ import org.pentaho.platform.scheduler2.ws.ListParamValue;
 import org.pentaho.platform.scheduler2.ws.MapParamValue;
 import org.pentaho.platform.scheduler2.ws.ParamValue;
 import org.pentaho.platform.scheduler2.ws.StringParamValue;
+import org.pentaho.platform.scheduler2.ws.test.TestQuartzScheduler;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.pentaho.test.platform.engine.core.PluginManagerAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -331,7 +332,7 @@ public class JaxWsSchedulerServiceIT {
       return stringParam;
     }
   }
-
+/*
   public static class TestQuartzScheduler extends QuartzScheduler {
     @Override
     protected String getCurrentUser() {
@@ -339,6 +340,7 @@ public class JaxWsSchedulerServiceIT {
       return super.getCurrentUser();
     }
   }
+*/
 
   @Test( timeout = 1000 * 5 * 60 )
   public void testUpdateComplexJob() throws SchedulerException {

--- a/scheduler/src/test/java/org/pentaho/platform/scheduler2/ws/test/TestQuartzScheduler.java
+++ b/scheduler/src/test/java/org/pentaho/platform/scheduler2/ws/test/TestQuartzScheduler.java
@@ -1,0 +1,32 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.scheduler2.ws.test;
+
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
+
+public class TestQuartzScheduler extends QuartzScheduler {
+
+  static final String TEST_USER = "TestUser";
+
+  @Override
+  protected String getCurrentUser() {
+    SecurityHelper.getInstance().becomeUser( TEST_USER );
+    return super.getCurrentUser();
+  }
+}


### PR DESCRIPTION
@pedrofvteixeira This should resolve the issue of extensions looking for JaxWsSchedulerServiceIT. TestQuartzScheduler is now packaged in pentaho-platform-scheduler-tests. Compiles, tests, and ITs run fine locally.