### PR TITLE
[BACKLOG-12101] Mavenize platform

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -518,7 +518,7 @@
               </artifactItems>
             </configuration>
           </execution>
-          <!-- Copy all the dependency defined with dependency tag into lib folder -->
+          <!-- Copy all the dependency defined with dependency tag into WEB-INF/lib folder -->
           <execution>
             <id>copy-dependencies</id>
             <phase>package</phase>
@@ -526,7 +526,10 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <outputDirectory>${prep.pentaho.war.lib.dir}</outputDirectory>
+              <excludeArtifactIds>gwt-user,postgresql,jtds,h2,hsqldb,mysql-connector-java</excludeArtifactIds>
+              <excludeGroupIds>com.h2database</excludeGroupIds>
+              <prependGroupId>false</prependGroupId>
             </configuration>
           </execution>
           <!-- Copying to tomcat/lib -->
@@ -553,7 +556,7 @@
               <includeArtifactIds>cglib-nodep,jaxen</includeArtifactIds>
             </configuration>
           </execution>
-        </executions>
+         </executions>
       </plugin>
 
     <plugin>
@@ -613,35 +616,6 @@
         </execution>
         <!-- [END] copy package-res and package-res-merged-server configuration
         files into assembly/target/pentaho-server -->
-
-        <execution>
-          <id>prepare-war-lib-dir</id>
-          <phase>package</phase>
-          <goals>
-            <goal>copy-resources</goal>
-          </goals>
-          <configuration>
-            <outputDirectory>${prep.pentaho.war.lib.dir}</outputDirectory>
-            <resources>
-              <resource>
-                <directory>${lib.dir}</directory>
-                <excludes>
-                  <exclude>*servlet-api-*.jar</exclude>
-                  <exclude>gwt-user-*.jar</exclude>
-                  <exclude>mysql-connector-*.jar</exclude>
-                  <exclude>postgres*.jar</exclude>
-                  <exclude>jtds-*.jar</exclude>
-                  <exclude>h2-*.jar</exclude>
-                  <exclude>hsqldb-*.jar</exclude>
-                  <exclude>*-sources.jar</exclude>
-                  <!-- TODO: Remove the line below when we fix the circular
-                    dependency between kettle-engine and metadata -->
-                  <exclude>hibernate-3.2.6.ga.jar</exclude>
-                </excludes>
-              </resource>
-            </resources>
-          </configuration>
-        </execution>
         <!--  Copy context.xml to target/resources -->
         <execution>
           <id>copy-rdbms-context</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1674,7 +1674,7 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>${postgresql.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -1686,7 +1686,7 @@
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>${hsqldb.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -1698,7 +1698,7 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>${h2.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>infobright</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -154,7 +154,6 @@
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
 			<version>${aspectjrt.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -328,7 +327,6 @@
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-xc</artifactId>
 			<version>${jackson.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -340,7 +338,6 @@
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>${jackson.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -424,7 +421,6 @@
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
 			<version>${activation.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -520,7 +516,6 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-ehcache</artifactId>
 			<version>${hibernate-ehcache.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -556,7 +551,6 @@
 			<groupId>asm</groupId>
 			<artifactId>asm-attrs</artifactId>
 			<version>${asm-attrs.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -604,7 +598,6 @@
 			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-core</artifactId>
 			<version>${jackrabbit.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>pentaho</groupId>
@@ -616,7 +609,6 @@
 			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-data</artifactId>
 			<version>${jackrabbit.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>


### PR DESCRIPTION
	- Removed some of the optional tags to ensure that the dependency
	  is pulled in at the time of assembly
        - Replaced copy-resources with copy-dependency to copy all the
	  depepndency to WEB-INF/lib
        - Updated database driver related jars from compile to provided
	  scope in extensions